### PR TITLE
Add Dependabot to CI and pin Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,16 +11,22 @@ updates:
       interval: daily
 
   - package-ecosystem: npm
-    directory: /keysas-admin
+    directories:
+      - /keysas-admin
+      - /keysas-firewall/tray-app
+      - /keysas-frontend
     schedule:
       interval: daily
+    # Disable version updates for npm dependencies, only open PRs for security updates
+    open-pull-requests-limit: 0
 
-  - package-ecosystem: npm
-    directory: /keysas-firewall/tray-app
+  - package-ecosystem: cargo
+    directories:
+      - '**/Cargo.toml'
     schedule:
       interval: daily
-
-  - package-ecosystem: npm
-    directory: /keysas-frontend
-    schedule:
-      interval: daily
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /.github
+    schedule:
+      interval: daily
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: npm
+    directory: /keysas-admin
+    schedule:
+      interval: daily
+
+  - package-ecosystem: npm
+    directory: /keysas-firewall/tray-app
+    schedule:
+      interval: daily
+
+  - package-ecosystem: npm
+    directory: /keysas-frontend
+    schedule:
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: /.github
     schedule:
       interval: daily
+    groups:
+      actions-updates:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "Github-Actions"
 
   - package-ecosystem: github-actions
     directory: /
@@ -21,9 +27,11 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
     groups:
-      all-non-major-dependencies:
+      npm-updates:
         patterns:
           - "*"
+    commit-message:
+      prefix: "NPM-dependencies"
 
   - package-ecosystem: cargo
     directories:
@@ -40,9 +48,11 @@ updates:
     schedule:
       interval: daily
     groups:
-      dependencies:
+      cargo-updates:
         patterns:
           - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "Cargo-dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,58 +1,58 @@
 version: 2
 updates:
-  - package-ecosystem: pip
-    directory: /.github
-    schedule:
-      interval: daily
-    groups:
-      actions-updates:
-        patterns:
-          - "*"
-    commit-message:
-      prefix: "Github-Actions"
+- package-ecosystem: pip
+  directory: /.github
+  schedule:
+    interval: daily
 
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  groups:
+    actions-updates:
+      patterns:
+      - "*"
+  commit-message:
+    prefix: "Github-Actions"
 
-  - package-ecosystem: npm
-    directories:
-      - /keysas-admin
-      - /keysas-firewall/tray-app
-      - /keysas-frontend
-    schedule:
-      interval: daily
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      npm-updates:
-        patterns:
-          - "*"
-    commit-message:
-      prefix: "NPM-dependencies"
+- package-ecosystem: npm
+  directories:
+  - /keysas-admin
+  - /keysas-firewall/tray-app
+  - /keysas-frontend
+  schedule:
+    interval: daily
+  ignore:
+  - dependency-name: "*"
+    update-types: [ "version-update:semver-major" ]
+  groups:
+    npm-updates:
+      patterns:
+      - "*"
+  commit-message:
+    prefix: "NPM-dependencies"
 
-  - package-ecosystem: cargo
-    directories:
-      - /keysas-firewall/daemon
-      - /keysas-core
-      - /keysas-backend
-      - /keysas-firewall/libmailslot
-      - /keysas_lib
-      - /keysas-firewall/tray-app/src-tauri
-      - /keysas-io
-      - /keysas-sign
-      - /keysas-admin/src-tauri
-      - /keysas-fido
-    schedule:
-      interval: daily
-    groups:
-      cargo-updates:
-        patterns:
-          - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    commit-message:
-      prefix: "Cargo-dependencies"
+- package-ecosystem: cargo
+  directories:
+  - /keysas-firewall/daemon
+  - /keysas-core
+  - /keysas-backend
+  - /keysas-firewall/libmailslot
+  - /keysas_lib
+  - /keysas-firewall/tray-app/src-tauri
+  - /keysas-io
+  - /keysas-sign
+  - /keysas-admin/src-tauri
+  - /keysas-fido
+  schedule:
+    interval: daily
+  groups:
+    cargo-updates:
+      patterns:
+      - "*"
+  ignore:
+  - dependency-name: "*"
+    update-types: [ "version-update:semver-major" ]
+  commit-message:
+    prefix: "Cargo-dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,16 +17,32 @@ updates:
       - /keysas-frontend
     schedule:
       interval: daily
-    # Disable version updates for npm dependencies, only open PRs for security updates
-    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    groups:
+      all-non-major-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: cargo
     directories:
-      - '**/Cargo.toml'
+      - /keysas-firewall/daemon
+      - /keysas-core
+      - /keysas-backend
+      - /keysas-firewall/libmailslot
+      - /keysas_lib
+      - /keysas-firewall/tray-app/src-tauri
+      - /keysas-io
+      - /keysas-sign
+      - /keysas-admin/src-tauri
+      - /keysas-fido
     schedule:
       interval: daily
     groups:
       dependencies:
         patterns:
           - "*"
-    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -2,7 +2,7 @@ name: Generate the SBOM and deploy it to GitHub Pages
 
 on:
   push:
-    branches: [Develop, main]
+    branches: [dev, main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -5,18 +5,23 @@ on:
     branches: [Develop, main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   generate-sbom:
+    permissions:
+      contents: write  # for peaceiris/actions-gh-pages to push pages branch
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: nightly
           override: true
@@ -71,7 +76,7 @@ jobs:
         run: cp .github/assets/index.html output/index.html
 
       - name: Deploy on GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./output


### PR DESCRIPTION
Hi !

This PR adds a the following changes:

- Dependabot configuration file to help maintain the GitHub Actions, Python and NPM dependencies
- Apply best practices to the SBOM workflow, by explicitly reducing the permissions for the jobs, and by pinning the Actions to their hash commits (updates are automatically handled by Dependabot)