### PR TITLE
Replace bincode with rkyv for IPC serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ keysas-usbfilter/minifilter/smvstats.txt
 keysas-usbfilter/tray-app/package-lock.json
 keysas-firewall/install/Output/
 keysas-firewall/installer/=/*
+.cargo/

--- a/keysas-core/Cargo.toml
+++ b/keysas-core/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["security", "command-line-utilities", "cryptography"]
 
 [dependencies]
 anyhow = "1.0"
-bincode= { version = "2", default-features = false, features = ["std", "derive"] }
+rkyv = { version = "0.8", default-features = false, features = ["std", "bytecheck"] }
 serde_derive = "1.0"
 serde = "1.0"
 nix = { version = "0.29", features = ["fs"]}

--- a/keysas-core/src/keysas-in/main.rs
+++ b/keysas-core/src/keysas-in/main.rs
@@ -48,7 +48,7 @@ use keysas_lib::{convert_ioslice, init_logger, list_files, sha256_digest};
 
 const CONFIG_DIRECTORY: &str = "/etc/keysas";
 
-#[derive(bincode::Encode, Debug, Clone)]
+#[derive(rkyv::Archive, rkyv::Serialize, Debug, Clone)]
 struct FileMetadata {
     filename: String,
     digest: String,
@@ -201,11 +201,10 @@ fn send_files(files: &[String], stream: &UnixStream, sas_in: &String) -> Result<
                         Err(e) => error!("Cannot remove ioerror report: {e}"),
                     }
                 }
-                let config = bincode::config::standard();
-                let data: Vec<u8> = match bincode::encode_to_vec(&m, config) {
-                    Ok(d) => d,
+                let data = match rkyv::to_bytes::<rkyv::rancor::Error>(&m) {
+                    Ok(d) => d.into_vec(),
                     Err(_e) => {
-                        error!("Failed to serialize FileMetadataa");
+                        error!("Failed to serialize FileMetadata");
                         return None;
                     }
                 };

--- a/keysas-core/src/keysas-out/main.rs
+++ b/keysas-core/src/keysas-out/main.rs
@@ -85,7 +85,7 @@ use std::str;
 mod sandbox;
 
 /// Structure representing a file and its metadata in the daemon
-#[derive(bincode::Decode, Debug)]
+#[derive(Debug)]
 pub struct FileData {
     /// File descriptor
     fd: i32,
@@ -175,8 +175,8 @@ fn parse_messages(messages: Messages, buffer: &[u8]) -> Vec<FileData> {
         .flatten()
         .map(|fd| {
             // Deserialize metadata into a [FileMetadata] struct
-            bincode::decode_from_slice::<FileMetadata, _>(buffer, bincode::config::standard())
-                .map(|(meta, _)| FileData { fd, md: meta })
+            rkyv::from_bytes::<FileMetadata, rkyv::rancor::Error>(buffer)
+                .map(|meta| FileData { fd, md: meta })
                 .unwrap_or_else(|e| {
                     warn!(
                         "Failed to deserialize message from keysas-transit: {e}, killing myself."
@@ -350,16 +350,16 @@ fn main() -> Result<()> {
         let bufs_in = &mut [IoSliceMut::new(&mut buf_in[..])][..];
 
         // Listen for message on socket
-        match sock_out.recv_vectored_with_ancillary(bufs_in, &mut ancillary_in) {
-            Ok(_) => (),
+        let recv_size = match sock_out.recv_vectored_with_ancillary(bufs_in, &mut ancillary_in) {
+            Ok(size) => size,
             Err(e) => {
                 warn!("Failed to receive fds from in: {e}");
                 process::exit(1);
             }
-        }
+        };
 
         // Parse messages received
-        let files = parse_messages(ancillary_in.messages(), &buf_in);
+        let files = parse_messages(ancillary_in.messages(), &buf_in[..recv_size]);
 
         // Output file
         output_files(files, &config, sign_keys.as_ref(), &sign_cert)?;

--- a/keysas-core/src/keysas-transit/main.rs
+++ b/keysas-core/src/keysas-transit/main.rs
@@ -51,7 +51,7 @@ mod sandbox;
 
 const CONFIG_DIRECTORY: &str = "/etc/keysas";
 
-#[derive(bincode::Decode, Debug)]
+#[derive(rkyv::Archive, rkyv::Deserialize, Debug)]
 struct InputMetadata {
     filename: String,
     digest: String,
@@ -59,7 +59,7 @@ struct InputMetadata {
     is_corrupted: bool,
 }
 
-#[derive(bincode::Encode, Debug)]
+#[derive(rkyv::Archive, rkyv::Serialize, Debug)]
 struct FileMetadata {
     filename: String,
     digest: String,
@@ -236,16 +236,15 @@ fn parse_messages(messages: Messages, buffer: &[u8]) -> Vec<FileData> {
         .flatten()
         .filter_map(|fd| {
             // Deserialize metadata
-            let config = bincode::config::standard().with_limit::<4128>();
-            match bincode::decode_from_slice::<InputMetadata, _>(buffer, config) {
+            match rkyv::from_bytes::<InputMetadata, rkyv::rancor::Error>(buffer) {
                 Ok(meta) => {
                     // Initialize with failed value by default
-                    log::info!("Receiving fd of file: {}", &meta.0.filename);
+                    log::info!("Receiving fd of file: {}", &meta.filename);
                     Some(FileData {
                         fd,
                         md: FileMetadata {
-                            filename: meta.0.filename,
-                            digest: meta.0.digest,
+                            filename: meta.filename,
+                            digest: meta.digest,
                             is_digest_ok: false,
                             is_toobig: true,
                             size: 0,
@@ -254,8 +253,8 @@ fn parse_messages(messages: Messages, buffer: &[u8]) -> Vec<FileData> {
                             av_report: Vec::new(),
                             yara_pass: false,
                             yara_report: String::new(),
-                            timestamp: meta.0.timestamp,
-                            is_corrupted: meta.0.is_corrupted,
+                            timestamp: meta.timestamp,
+                            is_corrupted: meta.is_corrupted,
                             file_type: "Unknown".into(),
                         },
                     })
@@ -449,10 +448,9 @@ fn check_files(files: &mut Vec<FileData>, conf: &Configuration, clam_addr: &str)
 
 /// This functions send the files filedescriptor and metadata to the socket
 fn send_files(files: &Vec<FileData>, stream: &UnixStream) {
-    let config = bincode::config::standard();
     for file in files {
         // Get metadata
-        let data = match bincode::encode_to_vec(&file.md, config) {
+        let data = match rkyv::to_bytes::<rkyv::rancor::Error>(&file.md) {
             Ok(d) => d,
             Err(e) => {
                 error!("Failed to serialize: {e}");
@@ -605,16 +603,19 @@ fn main() -> Result<()> {
         let bufs_in = &mut [IoSliceMut::new(&mut buf_in[..])][..];
 
         // Listen for message on socket
-        match sock_in.recv_vectored_with_ancillary(bufs_in, &mut ancillary_in) {
-            Ok(size) => info!("Receiving data from keysas-in, message size: {size}"),
+        let recv_size = match sock_in.recv_vectored_with_ancillary(bufs_in, &mut ancillary_in) {
+            Ok(size) => {
+                info!("Receiving data from keysas-in, message size: {size}");
+                size
+            }
             Err(e) => {
                 warn!("Failed to receive fds from in: {e}");
                 process::exit(1);
             }
-        }
+        };
 
         // Parse messages received
-        let mut files = parse_messages(ancillary_in.messages(), &buf_in);
+        let mut files = parse_messages(ancillary_in.messages(), &buf_in[..recv_size]);
 
         // Run check on message received
         check_files(&mut files, &config, &url.clone());

--- a/keysas_lib/Cargo.toml
+++ b/keysas_lib/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = "0.3"
 base64 = "0.22"
-bincode= { version = "2", default-features = false, features = ["std", "derive"] }
+rkyv = { version = "0.8", default-features = false, features = ["std", "bytecheck"] }
 
 [dependencies.oqs]
 version = "0.11"

--- a/keysas_lib/src/file_report.rs
+++ b/keysas_lib/src/file_report.rs
@@ -108,7 +108,7 @@ pub struct FileReport {
 }
 
 /// Structure that holds a file metadata
-#[derive(Debug, Serialize, Deserialize, Clone, bincode::Decode)]
+#[derive(Debug, Serialize, Deserialize, Clone, rkyv::Archive, rkyv::Deserialize)]
 pub struct FileMetadata {
     /// Name of the file
     pub filename: String,


### PR DESCRIPTION
Bincode is unmaintained. This swaps it for rkyv 0.8 across the three-daemon pipeline (keysas-in → keysas-transit → keysas-out) and keysas_lib.

  Changes

  - Replace bincode v2 with rkyv 0.8 in keysas-core and keysas_lib
  - Update struct derives and encode/decode calls accordingly
  - Fix both keysas-transit and keysas-out to pass &buf[..recv_size] instead of the full 4128-byte buffer to deserialization (bincode tolerated trailing zeros, rkyv validates the whole buffer)
  - Remove unused bincode::Decode derive on FileData in keysas-out

Tests pass, two clippy warnings but outside the scope of this change.