### PR TITLE
Refactor/ssh rs to russh

### DIFF
--- a/keysas-admin/src-tauri/Cargo.toml
+++ b/keysas-admin/src-tauri/Cargo.toml
@@ -28,7 +28,8 @@ log = "0.4"
 tauri = { version = "2.3.1", features = [] }
 tauri-plugin-log = "2"
 # App dependencies
-ssh-rs = { version = "0.5", features = ["scp"] }
+russh = "0.60"
+tokio = { version = "1", features = ["fs", "io-util"] }
 anyhow = { version = "1.0", features = ["backtrace"] }
 sqlite = "0.37"
 pkcs8 = {version = "0.10", features = ["encryption", "pem"] }

--- a/keysas-admin/src-tauri/src/lib.rs
+++ b/keysas-admin/src-tauri/src/lib.rs
@@ -318,7 +318,7 @@ async fn init_keysas(ip: String, name: String, ca_pwd: String) -> Result<String,
     };
 
     // Connect to the host
-    let mut session = match connect_key(&ip, &ssh_key) {
+    let mut session = match connect_key(&ip, &ssh_key).await {
         Ok(tu) => tu,
         Err(e) => {
             log::error!("Failed to open ssh connection with station: {e}");
@@ -328,11 +328,11 @@ async fn init_keysas(ip: String, name: String, ca_pwd: String) -> Result<String,
 
     //  1. Generate a key pair for file signature on the station
     //  2. Recover the CSR for the keys
-    let (csr_cl, csr_pq) = match cmd_generate_key_and_get_csr(&mut session, &name) {
+    let (csr_cl, csr_pq) = match cmd_generate_key_and_get_csr(&mut session, &name).await {
         Ok(csrs) => csrs,
         Err(e) => {
             log::error!("Failed to generate key on station and get CSR: {e}");
-            session.close();
+            session.close().await;
             return Err(String::from("PKI error"));
         }
     };
@@ -349,7 +349,7 @@ async fn init_keysas(ip: String, name: String, ca_pwd: String) -> Result<String,
         Ok(k) => k,
         Err(e) => {
             log::error!("Failed to load station CA key: {e}");
-            session.close();
+            session.close().await;
             return Err(String::from("PKI error"));
         }
     };
@@ -365,7 +365,7 @@ async fn init_keysas(ip: String, name: String, ca_pwd: String) -> Result<String,
         Ok(k) => k,
         Err(e) => {
             log::error!("Failed to load station USB key: {e}");
-            session.close();
+            session.close().await;
             return Err(String::from("PKI error"));
         }
     };
@@ -375,7 +375,7 @@ async fn init_keysas(ip: String, name: String, ca_pwd: String) -> Result<String,
         Ok(c) => c,
         Err(e) => {
             log::error!("Failed to generate certificate from request: {e}");
-            session.close();
+            session.close().await;
             return Err(String::from("PKI error"));
         }
     };
@@ -384,7 +384,7 @@ async fn init_keysas(ip: String, name: String, ca_pwd: String) -> Result<String,
         Ok(c) => c,
         Err(e) => {
             log::error!("Failed to generate certificate from request: {e}");
-            session.close();
+            session.close().await;
             return Err(String::from("PKI error"));
         }
     };
@@ -394,7 +394,7 @@ async fn init_keysas(ip: String, name: String, ca_pwd: String) -> Result<String,
     log::debug!("path_cl ST-PEM: {path_cl}");
     if let Err(e) = save_certificate(&cert_cl, Path::new(&path_cl)) {
         log::error!("Failed to save station certificate: {e}");
-        session.close();
+        session.close().await;
         return Err(String::from("PKI error"));
     }
 
@@ -403,37 +403,37 @@ async fn init_keysas(ip: String, name: String, ca_pwd: String) -> Result<String,
 
     if let Err(e) = save_certificate(&cert_cl, Path::new(&path_pq)) {
         log::error!("Failed to save station certificate: {e}");
-        session.close();
+        session.close().await;
         return Err(String::from("PKI error"));
     }
 
     // 4. Export the created certificates on the station
-    if let Err(e) = send_cert_to_station(&mut session, &cert_cl, "file-cl") {
+    if let Err(e) = send_cert_to_station(&mut session, &cert_cl, "file-cl").await {
         log::error!("Failed to load certificate on the station: {e}");
-        session.close();
+        session.close().await;
         return Err(String::from("Connection error"));
     }
 
-    if let Err(e) = send_cert_to_station(&mut session, &cert_pq, "file-pq") {
+    if let Err(e) = send_cert_to_station(&mut session, &cert_pq, "file-pq").await {
         log::error!("Failed to load certificate on the station: {e}");
-        session.close();
+        session.close().await;
         return Err(String::from("Connection error"));
     }
 
     // 5. Finally it loads the admin USB signing certificate
-    if let Err(e) = send_cert_to_station(&mut session, &usb_keys.classic_cert, "usb-cl") {
+    if let Err(e) = send_cert_to_station(&mut session, &usb_keys.classic_cert, "usb-cl").await {
         log::error!("Failed to load certificate on the station: {e}");
-        session.close();
+        session.close().await;
         return Err(String::from("Connection error"));
     }
 
-    if let Err(e) = send_cert_to_station(&mut session, &usb_keys.pq_cert, "usb-pq") {
+    if let Err(e) = send_cert_to_station(&mut session, &usb_keys.pq_cert, "usb-pq").await {
         log::error!("Failed to load certificate on the station: {e}");
-        session.close();
+        session.close().await;
         return Err(String::from("Connection error"));
     }
 
-    session.close();
+    session.close().await;
 
     Ok(String::from("true"))
 }
@@ -453,7 +453,7 @@ async fn update(ip: String) -> bool {
     log::error!("Rust will try updating host: {host}");
 
     // Connect to the host
-    let mut session = match connect_key(&ip, &private_key) {
+    let mut session = match connect_key(&ip, &private_key).await {
         Ok(s) => s,
         Err(e) => {
             log::error!("Failed to open ssh connection with station: {e}");
@@ -466,17 +466,19 @@ async fn update(ip: String) -> bool {
         &String::from(
             "sudo /usr/bin/apt update && sudo /usr/bin/apt -y dist-upgrade && sudo /bin/systemctl reboot ",
         ),
-    ) {
+    )
+    .await
+    {
         Ok(_) => {
             log::info!("Trying to update and rebooting...");
         }
         Err(why) => {
             log::error!("Error while updating: {why:?}");
-            session.close();
+            session.close().await;
             return false;
         }
     }
-    session.close();
+    session.close().await;
     true
 }
 
@@ -493,7 +495,7 @@ async fn reboot(ip: String) -> bool {
     // Connect to the host
     let host = format!("{}{}", ip.trim(), ":22");
     log::info!("Rust will try rebooting host: {host}");
-    let mut session = match connect_key(&ip, &private_key) {
+    let mut session = match connect_key(&ip, &private_key).await {
         Ok(s) => s,
         Err(e) => {
             log::error!("Failed to open ssh connection with station: {e}");
@@ -501,17 +503,17 @@ async fn reboot(ip: String) -> bool {
         }
     };
 
-    match session_exec(&mut session, &String::from("sudo /bin/systemctl reboot")) {
+    match session_exec(&mut session, &String::from("sudo /bin/systemctl reboot")).await {
         Ok(_) => {
             log::info!("Keysas station is rebooting !");
         }
         Err(why) => {
             log::error!("Rust error on open_exec: {why:?}");
-            session.close();
+            session.close().await;
             return false;
         }
     }
-    session.close();
+    session.close().await;
     true
 }
 
@@ -526,21 +528,21 @@ async fn shutdown(ip: String) -> bool {
         }
     };
     // Connect to the host
-    let mut session = match connect_key(&ip, &private_key) {
+    let mut session = match connect_key(&ip, &private_key).await {
         Ok(s) => s,
         Err(e) => {
             log::error!("Failed to open ssh connection with station: {e}");
             return false;
         }
     };
-    match session_exec(&mut session, &String::from("sudo /bin/systemctl poweroff")) {
+    match session_exec(&mut session, &String::from("sudo /bin/systemctl poweroff")).await {
         Ok(_) => {
             log::info!("Keysas station is shutting down.");
-            session.close();
+            session.close().await;
         }
         Err(why) => {
             log::error!("Rust error on open_exec: {why:?}");
-            session.close();
+            session.close().await;
             return false;
         }
     }
@@ -561,7 +563,7 @@ async fn export_sshpubkey(ip: String) -> bool {
     };
     log::info!("Exporting public SSH key to {ip:?}");
     // Connect to the host
-    let mut session = match connect_pwd(&ip) {
+    let mut session = match connect_pwd(&ip).await {
         Ok(s) => s,
         Err(e) => {
             log::error!("Failed to open ssh connection with station: {e}");
@@ -573,13 +575,15 @@ async fn export_sshpubkey(ip: String) -> bool {
         &mut session,
         public_key.trim(),
         &String::from("/home/keysas/.ssh/authorized_keys"),
-    ) {
+    )
+    .await
+    {
         Ok(_) => {
             log::info!("authorized_keys successfully s-copied !");
         }
         Err(e) => {
             log::error!("Rust error on upload: {e:?}");
-            session.close();
+            session.close().await;
             return false;
         }
     }
@@ -594,16 +598,18 @@ async fn export_sshpubkey(ip: String) -> bool {
                 echo 'PasswordAuthentication no' | sudo tee -a /etc/ssh/sshd_config > /dev/null; \
              fi && sudo systemctl restart sshd",
         ),
-    ) {
+    )
+    .await
+    {
         Ok(res) => {
             log::debug!("Command output: {}", String::from_utf8(res).unwrap());
             log::info!("Password authentication has been disabled.");
-            session.close();
+            session.close().await;
             true
         }
         Err(e) => {
             log::error!("Rust error on open_exec: {e:?}");
-            session.close();
+            session.close().await;
             false
         }
     }
@@ -635,24 +641,24 @@ async fn is_alive(name: String) -> Result<bool, String> {
     };
 
     // Connect to the host
-    let mut session = match connect_key(&ip, &private_key) {
+    let mut session = match connect_key(&ip, &private_key).await {
         Ok(s) => s,
         Err(e) => {
             log::error!("Failed to open ssh connection with station: {e}");
             return Err(String::from("Store error"));
         }
     };
-    match session_exec(&mut session, &String::from("/bin/systemctl status keysas")) {
+    match session_exec(&mut session, &String::from("/bin/systemctl status keysas")).await {
         Ok(_) => {
             log::info!("Keysas is alive.");
         }
         Err(why) => {
             log::error!("Cannot execute command status: {why:?}");
-            session.close();
+            session.close().await;
             return Err(String::from("Store error"));
         }
     }
-    session.close();
+    session.close().await;
     Ok(true)
 }
 

--- a/keysas-admin/src-tauri/src/ssh_wrapper.rs
+++ b/keysas-admin/src-tauri/src/ssh_wrapper.rs
@@ -1,71 +1,322 @@
-use std::error::Error;
-use std::net::TcpStream;
+use anyhow::{Context, anyhow};
+use russh::client::{self, Handle};
+use russh::keys::{Algorithm as KeyAlg, HashAlg, PrivateKeyWithHashAlg, load_secret_key};
+use russh::{ChannelMsg, Preferred, cipher, compression, kex, mac};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
 
-use ssh::LocalSession;
-use ssh::SshResult;
-use ssh::algorithm;
-use ssh::create_session_without_default;
-
-const TIMEOUT: u64 = 60 * 1000;
+const TIMEOUT: Duration = Duration::from_secs(60 * 1000);
 const USER: &str = "keysas";
 const PASSWORD: &str = "Changeme007";
 
-/// Create SSH connexion with RSA or ECC key
-pub fn connect_key(ip: &str, private_key: &str) -> Result<LocalSession<TcpStream>, Box<dyn Error>> {
-    let host = format!("{}{}", ip.trim(), ":22");
-    let connector = create_session_without_default()
-        .username(USER)
-        .private_key_path(private_key.trim())
-        .add_kex_algorithms(algorithm::Kex::Curve25519Sha256)
-        .add_kex_algorithms(algorithm::Kex::EcdhSha2Nistrp256)
-        .add_pubkey_algorithms(algorithm::PubKey::SshEd25519)
-        .add_pubkey_algorithms(algorithm::PubKey::RsaSha2_512)
-        .add_pubkey_algorithms(algorithm::PubKey::RsaSha2_256)
-        .add_enc_algorithms(algorithm::Enc::Chacha20Poly1305Openssh)
-        .add_compress_algorithms(algorithm::Compress::None)
-        .add_mac_algortihms(algorithm::Mac::HmacSha2_512)
-        .add_mac_algortihms(algorithm::Mac::HmacSha2_256)
-        .timeout(Some(std::time::Duration::from_secs(TIMEOUT)))
-        .connect(host)?;
-    let session = connector.run_local();
-    Ok(session)
+#[derive(Debug)]
+pub struct AcceptAllHandler;
+
+impl client::Handler for AcceptAllHandler {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        server_public_key: &russh::keys::ssh_key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        log::debug!(
+            "SSH host key fingerprint: {}",
+            server_public_key.fingerprint(Default::default())
+        );
+        Ok(true)
+    }
 }
 
-/// Create SSH connexion with password
-pub fn connect_pwd(ip: &str) -> SshResult<LocalSession<TcpStream>> {
-    let host = format!("{}{}", ip.trim(), ":22");
-    let connector = create_session_without_default()
-        .username(USER)
-        .password(PASSWORD)
-        .add_kex_algorithms(algorithm::Kex::Curve25519Sha256)
-        .add_kex_algorithms(algorithm::Kex::EcdhSha2Nistrp256)
-        .add_pubkey_algorithms(algorithm::PubKey::SshEd25519)
-        .add_pubkey_algorithms(algorithm::PubKey::RsaSha2_512)
-        .add_pubkey_algorithms(algorithm::PubKey::RsaSha2_256)
-        .add_enc_algorithms(algorithm::Enc::Chacha20Poly1305Openssh)
-        .add_compress_algorithms(algorithm::Compress::None)
-        .add_mac_algortihms(algorithm::Mac::HmacSha2_512)
-        .add_mac_algortihms(algorithm::Mac::HmacSha2_256)
-        .timeout(Some(std::time::Duration::from_secs(TIMEOUT)))
-        .connect(host)?;
-    let session = connector.run_local();
-    Ok(session)
+pub struct KeysasSshSession {
+    handle: Handle<AcceptAllHandler>,
 }
 
-pub fn session_exec(
-    session: &mut LocalSession<TcpStream>,
+fn build_config() -> client::Config {
+    client::Config {
+        inactivity_timeout: Some(TIMEOUT),
+        preferred: Preferred {
+            kex: std::borrow::Cow::Borrowed(&[kex::CURVE25519, kex::ECDH_SHA2_NISTP256]),
+            key: std::borrow::Cow::Borrowed(&[
+                KeyAlg::Ed25519,
+                KeyAlg::Rsa {
+                    hash: Some(HashAlg::Sha512),
+                },
+                KeyAlg::Rsa {
+                    hash: Some(HashAlg::Sha256),
+                },
+            ]),
+            cipher: std::borrow::Cow::Borrowed(&[cipher::CHACHA20_POLY1305]),
+            mac: std::borrow::Cow::Borrowed(&[mac::HMAC_SHA512, mac::HMAC_SHA256]),
+            compression: std::borrow::Cow::Borrowed(&[compression::NONE]),
+        },
+        ..client::Config::default()
+    }
+}
+
+/// Create SSH connection with RSA or ECC key.
+pub async fn connect_key(ip: &str, private_key: &str) -> anyhow::Result<KeysasSshSession> {
+    let host = format!("{}{}", ip.trim(), ":22");
+    let cfg = Arc::new(build_config());
+
+    let key_pair = load_secret_key(private_key.trim(), None)
+        .with_context(|| format!("loading SSH private key from {private_key}"))?;
+
+    let mut handle = client::connect(cfg, host, AcceptAllHandler)
+        .await
+        .context("opening SSH transport")?;
+
+    let rsa_hash = handle.best_supported_rsa_hash().await?.flatten();
+    let pk = PrivateKeyWithHashAlg::new(Arc::new(key_pair), rsa_hash);
+    let auth = handle
+        .authenticate_publickey(USER, pk)
+        .await
+        .context("publickey authentication")?;
+    if !auth.success() {
+        return Err(anyhow!("SSH publickey authentication rejected"));
+    }
+    Ok(KeysasSshSession { handle })
+}
+
+/// Create SSH connection with password.
+pub async fn connect_pwd(ip: &str) -> anyhow::Result<KeysasSshSession> {
+    let host = format!("{}{}", ip.trim(), ":22");
+    let cfg = Arc::new(build_config());
+    let mut handle = client::connect(cfg, host, AcceptAllHandler)
+        .await
+        .context("opening SSH transport")?;
+    let auth = handle
+        .authenticate_password(USER, PASSWORD)
+        .await
+        .context("password authentication")?;
+    if !auth.success() {
+        return Err(anyhow!("SSH password authentication rejected"));
+    }
+    Ok(KeysasSshSession { handle })
+}
+
+pub async fn session_exec(
+    session: &mut KeysasSshSession,
     command: &str,
-) -> Result<Vec<u8>, Box<dyn Error>> {
-    let channel = session.open_exec()?;
-    let output = channel.send_command(command)?;
-    Ok(output)
+) -> anyhow::Result<Vec<u8>> {
+    let mut channel = session.handle.channel_open_session().await?;
+    channel.exec(true, command).await?;
+    let mut out = Vec::new();
+    let mut eof_seen = false;
+    let mut exit_seen = false;
+    while let Some(msg) = channel.wait().await {
+        match msg {
+            ChannelMsg::Data { data } => out.extend_from_slice(&data),
+            ChannelMsg::ExtendedData { data, .. } => out.extend_from_slice(&data),
+            ChannelMsg::ExitStatus { exit_status } => {
+                if exit_status != 0 {
+                    log::debug!("remote command `{command}` exited with status {exit_status}");
+                }
+                exit_seen = true;
+            }
+            ChannelMsg::Eof => eof_seen = true,
+            ChannelMsg::Close => break,
+            _ => {}
+        }
+        if eof_seen && exit_seen {
+            break;
+        }
+    }
+    Ok(out)
 }
 
-pub fn session_upload(
-    session: &mut LocalSession<TcpStream>,
+pub async fn session_upload(
+    session: &mut KeysasSshSession,
     path_l: &str,
     path_d: &str,
-) -> SshResult<()> {
-    let channel = session.open_scp()?;
-    channel.upload(path_l, path_d)
+) -> anyhow::Result<()> {
+    scp_upload(&session.handle, path_l, path_d).await
+}
+
+impl KeysasSshSession {
+    pub async fn close(self) {
+        let _ = self
+            .handle
+            .disconnect(russh::Disconnect::ByApplication, "", "en")
+            .await;
+    }
+}
+
+/// SCP "to" mode upload. Wire protocol:
+///   server -> 0x00                          (initial readiness ack)
+///   client -> "C0644 <size> <basename>\n"
+///   server -> 0x00                          (ack header)
+///   client -> <size> bytes of file data
+///   client -> 0x00                          (terminator)
+///   server -> 0x00                          (ack body)
+///   client -> EOF, channel closes; check exit status.
+async fn scp_upload(
+    handle: &Handle<AcceptAllHandler>,
+    path_l: &str,
+    path_d: &str,
+) -> anyhow::Result<()> {
+    let path = std::path::Path::new(path_l);
+    let basename = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| anyhow!("local path has no usable basename: {path_l}"))?;
+
+    let metadata = tokio::fs::metadata(&path)
+        .await
+        .with_context(|| format!("stat {path_l}"))?;
+    let size = metadata.len();
+
+    let quoted_remote = shlex::try_quote(path_d)?;
+    let cmd = format!("scp -t {quoted_remote}");
+
+    let mut channel = handle.channel_open_session().await?;
+    channel.exec(true, cmd).await?;
+
+    expect_ack(&mut channel).await.context("scp: initial ack")?;
+
+    let cline = format!("C0644 {size} {basename}\n");
+    channel
+        .data(cline.as_bytes())
+        .await
+        .map_err(|_| anyhow!("scp: failed to send C-line"))?;
+    expect_ack(&mut channel).await.context("scp: C-line ack")?;
+
+    let mut file = File::open(&path)
+        .await
+        .with_context(|| format!("open {path_l}"))?;
+    let mut buf = vec![0u8; 32 * 1024];
+    loop {
+        let n = file.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        channel
+            .data(&buf[..n])
+            .await
+            .map_err(|_| anyhow!("scp: failed to send file body"))?;
+    }
+
+    channel
+        .data(&[0u8][..])
+        .await
+        .map_err(|_| anyhow!("scp: failed to send terminator"))?;
+    expect_ack(&mut channel).await.context("scp: body ack")?;
+
+    channel.eof().await?;
+    let mut exit: Option<u32> = None;
+    while let Some(msg) = channel.wait().await {
+        match msg {
+            ChannelMsg::ExitStatus { exit_status } => exit = Some(exit_status),
+            ChannelMsg::Close => break,
+            _ => {}
+        }
+    }
+    match exit {
+        Some(0) | None => Ok(()),
+        Some(code) => Err(anyhow!("remote scp exited with status {code}")),
+    }
+}
+
+fn parse_ack_byte(data: &[u8]) -> anyhow::Result<()> {
+    if data.is_empty() {
+        return Err(anyhow!("scp: empty ack frame"));
+    }
+    match data[0] {
+        0 => Ok(()),
+        1 | 2 => {
+            let detail = String::from_utf8_lossy(&data[1..]).trim_end().to_string();
+            Err(anyhow!(
+                "scp peer reported error (code {}): {}",
+                data[0],
+                detail
+            ))
+        }
+        other => Err(anyhow!("scp peer sent unexpected byte {other:#x}")),
+    }
+}
+
+async fn expect_ack(channel: &mut russh::Channel<russh::client::Msg>) -> anyhow::Result<()> {
+    while let Some(msg) = channel.wait().await {
+        if let ChannelMsg::Data { data } = msg {
+            if data.is_empty() {
+                continue;
+            }
+            return parse_ack_byte(&data);
+        }
+    }
+    Err(anyhow!("scp: channel closed without ack"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scp_cline_format() {
+        let cline = format!("C0644 {} {}\n", 42u64, "authorized_keys");
+        assert_eq!(cline, "C0644 42 authorized_keys\n");
+        assert_eq!(cline.as_bytes().last(), Some(&b'\n'));
+    }
+
+    #[test]
+    fn test_scp_cline_zero_size() {
+        let cline = format!("C0644 {} {}\n", 0u64, "empty.txt");
+        assert_eq!(cline, "C0644 0 empty.txt\n");
+    }
+
+    #[test]
+    fn test_parse_ack_byte_ok() {
+        assert!(parse_ack_byte(&[0u8]).is_ok());
+        assert!(parse_ack_byte(&[0u8, b'g', b'a', b'r', b'b']).is_ok());
+    }
+
+    #[test]
+    fn test_parse_ack_byte_warning() {
+        let err = parse_ack_byte(b"\x01scp: detail message\n")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("code 1"));
+        assert!(err.contains("scp: detail message"));
+        assert!(!err.ends_with('\n'), "trailing newline must be trimmed");
+    }
+
+    #[test]
+    fn test_parse_ack_byte_fatal() {
+        let err = parse_ack_byte(b"\x02boom").unwrap_err().to_string();
+        assert!(err.contains("code 2"));
+        assert!(err.contains("boom"));
+    }
+
+    #[test]
+    fn test_parse_ack_byte_unexpected() {
+        let err = parse_ack_byte(&[0x42u8, b'x']).unwrap_err().to_string();
+        assert!(
+            err.contains("0x42"),
+            "error should report the unexpected byte in hex: got {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_ack_byte_empty() {
+        assert!(parse_ack_byte(&[]).is_err());
+    }
+
+    #[test]
+    fn test_remote_path_quoting_preserves_spaces() {
+        let quoted = shlex::try_quote("/tmp/with space.txt").unwrap();
+        let cmd = format!("scp -t {quoted}");
+        assert!(cmd.contains("with space.txt"));
+        assert!(
+            !cmd.starts_with("scp -t /tmp/with space.txt"),
+            "unquoted path would be split into two args"
+        );
+    }
+
+    #[test]
+    fn test_basename_extraction() {
+        let p = std::path::Path::new("/home/op/.ssh/id_ed25519.pub");
+        let basename = p.file_name().and_then(|s| s.to_str()).unwrap();
+        assert_eq!(basename, "id_ed25519.pub");
+    }
 }

--- a/keysas-admin/src-tauri/src/store.rs
+++ b/keysas-admin/src-tauri/src/store.rs
@@ -81,20 +81,20 @@ pub fn get_ssh() -> Result<(String, String), anyhow::Error> {
 
                 connection.iterate(GET_PUBLIC_QUERY, |pairs| {
                     for &(key, value) in pairs.iter() {
-                        if key == "path" {
-                            if let Some(p) = value {
-                                public.push_str(p)
-                            }
+                        if key == "path"
+                            && let Some(p) = value
+                        {
+                            public.push_str(p)
                         }
                     }
                     true
                 })?;
                 connection.iterate(GET_PRIVATE_QUERY, |pairs| {
                     for &(key, value) in pairs.iter() {
-                        if key == "path" {
-                            if let Some(p) = value {
-                                private.push_str(p)
-                            }
+                        if key == "path"
+                            && let Some(p) = value
+                        {
+                            private.push_str(p)
                         }
                     }
                     true
@@ -288,11 +288,11 @@ pub fn get_pki_dir() -> Result<String, anyhow::Error> {
                 let mut result = String::new();
                 connection.iterate(query, |pairs| {
                     for &(key, value) in pairs.iter() {
-                        println!("{key:?}:{value:?}");
-                        if key == "directory" {
-                            if let Some(dir) = value {
-                                result.push_str(dir)
-                            }
+                        log::debug!("{key:?}:{value:?}");
+                        if key == "directory"
+                            && let Some(dir) = value
+                        {
+                            result.push_str(dir)
                         }
                     }
                     true
@@ -321,8 +321,6 @@ pub fn get_pki_info() -> Result<CertificateFields, anyhow::Error> {
                 };
                 connection.iterate(query, |pairs| {
                     for &(param, value) in pairs.iter() {
-                        //println!("param/value: {param}::::{value:?}");
-                        //println!("pair: {:?}", pairs);
                         match param {
                             "org_name" => result.org_name = Some(value.unwrap().to_string()),
                             "org_unit" => result.org_unit = Some(value.unwrap().to_string()),

--- a/keysas-admin/src-tauri/src/usb_sign.rs
+++ b/keysas-admin/src-tauri/src/usb_sign.rs
@@ -79,6 +79,7 @@ fn rm_last(value: &str) -> &str {
 
 /// Construct an hybrid signature from firmware information
 #[cfg(target_os = "linux")]
+#[allow(clippy::too_many_arguments)]
 fn sign_device(
     vendor: &str,
     model: &str,
@@ -129,7 +130,7 @@ pub fn watch_new_usb() -> Result<(String, String, String, String, String)> {
         };
 
         if result < 0 {
-            println!("Error: result is < 0.");
+            log::error!("poll() returned a negative value");
         }
 
         let event = match socket.iter().next() {

--- a/keysas-admin/src-tauri/src/utils.rs
+++ b/keysas-admin/src-tauri/src/utils.rs
@@ -1,3 +1,4 @@
+use crate::ssh_wrapper::KeysasSshSession;
 use crate::ssh_wrapper::session_exec;
 use crate::store::{drop_pki, init_store, set_pki_config};
 use anyhow::anyhow;
@@ -6,10 +7,8 @@ use keysas_lib::keysas_hybrid_keypair::HybridKeyPair;
 use pkcs8::LineEnding;
 use pkcs8::der::EncodePem;
 use shlex::try_quote;
-use ssh::LocalSession;
 use std::fs::File;
 use std::io::Write;
-use std::net::TcpStream;
 use std::path::Path;
 use x509_cert::Certificate;
 use x509_cert::der::DecodePem;
@@ -22,8 +21,8 @@ const PKI_ROOT_KEY_NAME: &str = "root";
 
 /// Wrapper function to triger a signing key generation on a station and
 /// recover CSRs from it
-pub fn cmd_generate_key_and_get_csr(
-    session: &mut LocalSession<TcpStream>,
+pub async fn cmd_generate_key_and_get_csr(
+    session: &mut KeysasSshSession,
     name: &str,
 ) -> Result<(CertReq, CertReq), anyhow::Error> {
     let name_escaped = try_quote(name)?;
@@ -32,7 +31,7 @@ pub fn cmd_generate_key_and_get_csr(
         "sudo /usr/bin/keysas-sign --generate", " --name ", name_escaped
     );
     log::error!("Command: {command:?}");
-    let cmd_res = match session_exec(session, &command) {
+    let cmd_res = match session_exec(session, &command).await {
         Ok(res) => res,
         Err(why) => {
             log::error!("Error on send_command: {why:?}");
@@ -83,8 +82,8 @@ pub fn cmd_generate_key_and_get_csr(
 ///     - file-pq: certificate for ML-DSA87 station files signing
 ///     - usb-cl: certificate for ED25519 USB signing
 ///     - usb-pq: certificate for ML-DSA87 USB signing
-pub fn send_cert_to_station(
-    session: &mut LocalSession<TcpStream>,
+pub async fn send_cert_to_station(
+    session: &mut KeysasSshSession,
     cert: &Certificate,
     kind: &str,
 ) -> Result<(), anyhow::Error> {
@@ -98,21 +97,21 @@ pub fn send_cert_to_station(
         "\"".to_owned() + &output + "\"",
     );
 
-    if let Err(e) = session_exec(session, &command) {
+    if let Err(e) = session_exec(session, &command).await {
         log::error!("Failed to load certificate on the station: {e}");
         return Err(anyhow!("Connection error"));
     }
 
     let command = "sudo /bin/chown keysas-out:keysas-out /etc/keysas/file-sign-cl.p8 /etc/keysas/file-sign-cl.pem /etc/keysas/file-sign-pq.p8 /etc/keysas/file-sign-pq.pem /etc/keysas/usb-ca-cl.pem /etc/keysas/usb-ca-pq.pem".to_string();
 
-    if let Err(e) = session_exec(session, &command) {
+    if let Err(e) = session_exec(session, &command).await {
         log::error!("Failed to chown files: {e}");
         return Err(anyhow!("Connection error"));
     }
 
     let command = "sudo /bin/systemctl restart keysas".to_string();
 
-    if let Err(e) = session_exec(session, &command) {
+    if let Err(e) = session_exec(session, &command).await {
         log::error!("Failed to restart Keysas: {e}");
         return Err(anyhow!("Connection error"));
     }


### PR DESCRIPTION
Replaces `ssh-rs` with `russh 0.60` in `keysas-admin/src-tauri`. The old crate has been unmaintained since 2024 (last commit, ~20 stale issues, no roadmap) and was the only blocker keeping the operator desktop on it.

  Strict drop-in: same algorithm set, same host-key behaviour, same `keysas` / `Changeme007` defaults, same timeout, same SCP-over-exec upload (no SFTP). Public function names are preserved; call sites in `lib.rs` and `utils.rs` just get `.await`. Error type unifies on `anyhow::Result` since `SshError` disappears with the crate.

  Tested end-to-end against an OpenSSH 10 sshd: `connect_pwd`, `connect_key`, `session_exec`, and `session_upload` (with byte-exact `sha256sum` parity on the uploaded `authorized_keys`). `init_keysas` against a real station still needs to be run before merge — I couldn't validate that path locally.

  A couple of pre-existing issues surfaced while testing, unrelated to the swap, worth a follow-up:

  - The confirmation dialogs in `ManageView.vue` and `DisplaySigningConfig.vue` pass `{ type: 'info' | 'warning' }` to `tauri-plugin-dialog`'s `confirm()`. Tauri 2 renamed that to `kind:`, so the dialogs silently no-op and the wrapped action never runs. Been broken since the Tauri v1→v2 upgrade.
  - The onboarding UI tells users to generate keys with `ssh-keygen -m PEM -t ed25519 -f mykey`. OpenSSH 10 rejects that combination outright (`invalid format`). Still works on the stable-distro releases operators are actually on, but won't work on anything bleeding-edge.